### PR TITLE
add(.github): Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for Go
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
## What

Configured Dependabot.

## Why

Resolves: https://github.com/KeisukeYamashita/go-vcl/issues/26
To manage dependencies and keep the project up to date.
